### PR TITLE
Don't take reference of return values.

### DIFF
--- a/src/core/web_contents_adapter.cpp
+++ b/src/core/web_contents_adapter.cpp
@@ -1264,8 +1264,8 @@ bool WebContentsAdapter::handleDropDataFileContents(const content::DropData &dro
         }
     }
 
-    const QString &fileName = toQt(dropData.file_description_filename);
-    const QString &filePath = d->dndTmpDir->filePath(fileName);
+    const QString fileName = toQt(dropData.file_description_filename);
+    const QString filePath = d->dndTmpDir->filePath(fileName);
     QFile file(filePath);
     if (!file.open(QIODevice::WriteOnly)) {
         qWarning("Cannot write temporary file %s.", qUtf8Printable(filePath));
@@ -1273,7 +1273,7 @@ bool WebContentsAdapter::handleDropDataFileContents(const content::DropData &dro
     }
     file.write(QByteArray::fromStdString(dropData.file_contents));
 
-    const QUrl &targetUrl = QUrl::fromLocalFile(filePath);
+    const QUrl targetUrl = QUrl::fromLocalFile(filePath);
     mimeData->setUrls(QList<QUrl>{targetUrl});
     return true;
 }


### PR DESCRIPTION
Several values are stored as a reference, when the return type of the called function is an object. This is not normally safe, although it may be ok in some circumstances. They were all introduced in commit 99f84ffd2c0c78014a24534a863aa1c755abd51c .

